### PR TITLE
Define distinct styles for free and literal transl. fields

### DIFF
--- a/xml2OO.xsl
+++ b/xml2OO.xsl
@@ -106,8 +106,18 @@ version="1.0">
   <xsl:template match="phrase/item" mode="items"> <!-- freeform in its own paragraph -->
 	<xsl:if test="@type!='segnum'">
 	  <text:p>
-		  <xsl:attribute name="text:style-name">Interlin_Freeform_Gloss_<xsl:value-of select="@lang"/></xsl:attribute>
-<xsl:choose>
+		
+		  <xsl:choose>
+            <xsl:when test="@type='gls'">
+  		      <xsl:attribute name="text:style-name">Interlin_Freeform_Gloss_<xsl:value-of select="@lang"/></xsl:attribute>
+            </xsl:when>
+
+            <xsl:when test="@type='lit'">
+		      <xsl:attribute name="text:style-name">Interlin_Literal_Gloss_<xsl:value-of select="@lang"/></xsl:attribute>
+            </xsl:when>
+		  </xsl:choose>
+		
+			    <xsl:choose>
                        <xsl:when test="@lang='en' and @type='gls'">
                              <xsl:text>Translation: </xsl:text>
                        </xsl:when>
@@ -133,7 +143,7 @@ version="1.0">
                              <xsl:text>Trans. of Spanish: </xsl:text>
                        </xsl:when>
                 </xsl:choose>		  
-		   <xsl:apply-templates/>
+		  <xsl:apply-templates/>
 	  </text:p>
 	</xsl:if>
   </xsl:template>

--- a/xml2OOStyles.xsl
+++ b/xml2OOStyles.xsl
@@ -347,6 +347,19 @@ if one WS is used only for word glosses, we will still generate a morpheme-gloss
 			</xsl:if>
 		</style:paragraph-properties>
 	</style:style>
+    <!--This was added by Natasha to separate styles for literal and free translations.-->
+	<style:style style:family="paragraph" style:class="text">
+		<!-- Careful! White space is significant in these elements, don't let VS pretty-print them.-->
+		<xsl:attribute name="style:name">Interlin_Literal_Gloss_<xsl:value-of select="@lang"/></xsl:attribute>
+		<xsl:attribute name="style:display-name">Interlin Literal Gloss <xsl:value-of select="@lang"/></xsl:attribute>
+		<xsl:attribute name="style:parent-style-name">Interlin_Analysis_<xsl:value-of select="@lang"/></xsl:attribute>
+		<style:paragraph-properties>
+			<xsl:if test="//language[@vernacular='true' and @RightToLeft='true']">
+				<xsl:attribute name="fo:text-align">start</xsl:attribute>
+			</xsl:if>
+		</style:paragraph-properties>
+	</style:style>
+
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Creates separate styles on LibreOffice export for free vs. literal translation lines of each language so they can be formatted separately